### PR TITLE
n-day triage: vuln vs patched margin, plus recall@k and abstain in eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ changed behavior (lowest similarity first):
    61.7%  deflate_stored
 ```
 
+for actual n-day work there is `triage`. build one corpus from the known
+vulnerable version of a function and one from the patched version, then rank an
+unknown build against both. a function close to the vulnerable side and clearly
+separated from the patched side is what you want in front of a human, not just a
+single match score you have to interpret:
+
+```
+$ fnprint index vuln.so    -o vuln.db
+$ fnprint index patched.so -o patched.db
+$ fnprint triage mystery.so --vuln vuln.db --patched patched.db
+43 functions triaged: 1 look vulnerable, 0 patched, 42 inconclusive
+
+review queue (vuln-leaning, strongest first):
+   addr         vuln%  patched%  margin  matches
+   0x000022f9  100.0     27.3   +72.7  adler32_z vs crc32_z
+```
+
+the 42 functions that are identical in both versions come back inconclusive on
+purpose, they can't be pinned to either side and shouldn't be flagged. `--margin`
+and `--min-sim` control how hard the two sides have to separate before it commits.
+
 ## how it works
 
 for each function:
@@ -96,6 +117,7 @@ cargo build --release   # binary at target/release/fnprint
 fnprint index <binary> [-o out.db]      fingerprint every function, optionally to a db
 fnprint match <a> <b>                   diff two binaries (or .db files) by behavior
 fnprint query <target> --corpus <db>    name unknown functions from a corpus
+fnprint triage <t> --vuln <db> --patched <db>   rank a build against vuln vs patched corpora
 fnprint eval <a> <b>                     accuracy metrics using symbol names as truth
 fnprint dump <binary> <func>            print the recorded effect trace (debugging)
 ```
@@ -119,6 +141,13 @@ task. measured on zlib 1.3.1 (84 functions), reproducible with `bench/run.sh`:
 | gcc/clang O2    | 59.1%  | 50.0%     |
 
 full table plus a second library (lua) in [bench/NUMBERS.md](bench/NUMBERS.md).
+
+`eval` also reports recall@3 / recall@5 and an abstention rate, since rank-1
+alone hides a lot. on gcc O0 -> O2 the top hit is right 93% of the time but the
+correct function is in the top 5 96.6% of the time, so a small review budget
+closes most of the gap. it also abstains (declines a confident "same" call)
+on the pairs it isn't sure about instead of guessing, which is why precision
+stays high while recall at the same threshold is low.
 
 the honest read: when at least one side has some behavioral richness (anything
 with `-O0`/`-O1`, or a cross-compiler pair at `-O0`) it lands in the 80-98%

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use fnprint_core::{
-    dump_traces, eval, index_bytes, match_by_name, query_corpus, source_str, IndexedFunc,
-    MIN_COMPLEXITY,
+    dump_traces, eval, index_bytes, match_by_name, query_corpus, source_str, triage, IndexedFunc,
+    Verdict, MIN_COMPLEXITY,
 };
 use fnprint_db::Db;
 use fnprint_emu::Config;
@@ -42,6 +42,20 @@ enum Cmd {
     },
     /// accuracy metrics between two builds, using symbol names as ground truth
     Eval { a: String, b: String },
+    /// n-day triage: rank a target against known-vulnerable and patched corpora
+    Triage {
+        target: String,
+        #[arg(long)]
+        vuln: String,
+        #[arg(long)]
+        patched: String,
+        /// a side has to be at least this similar to count as a real lead
+        #[arg(long, default_value_t = 0.6)]
+        min_sim: f64,
+        /// how far the two sides must separate before we commit to a verdict
+        #[arg(long, default_value_t = 0.08)]
+        margin: f64,
+    },
     /// print the recorded effect trace for one function (debugging)
     Dump { binary: String, func: String },
 }
@@ -57,6 +71,13 @@ fn main() -> Result<()> {
             threshold,
         } => cmd_query(&target, &corpus, threshold),
         Cmd::Eval { a, b } => cmd_eval(&a, &b),
+        Cmd::Triage {
+            target,
+            vuln,
+            patched,
+            min_sim,
+            margin,
+        } => cmd_triage(&target, &vuln, &patched, min_sim, margin),
         Cmd::Dump { binary, func } => cmd_dump(&binary, &func),
     }
 }
@@ -174,6 +195,8 @@ fn cmd_eval(a: &str, b: &str) -> Result<()> {
     let r = eval(&ia, &ib);
     println!("scored {} functions (had signal + a twin in B)", r.scored);
     println!("  rank-1 accuracy: {:.1}%", r.rank1_acc() * 100.0);
+    println!("  recall@3:        {:.1}%", r.recall_at(3) * 100.0);
+    println!("  recall@5:        {:.1}%", r.recall_at(5) * 100.0);
     println!("  MRR:             {:.3}", r.mrr());
     println!(
         "  precision@same:  {:.1}%  ({} tp / {} fp)",
@@ -182,6 +205,59 @@ fn cmd_eval(a: &str, b: &str) -> Result<()> {
         r.fp
     );
     println!("  recall@same:     {:.1}%", r.recall() * 100.0);
+    println!(
+        "  abstained:       {:.1}%  ({} of {} below same-threshold)",
+        r.abstain_rate() * 100.0,
+        r.abstained,
+        r.scored
+    );
+    Ok(())
+}
+
+fn cmd_triage(
+    target: &str,
+    vuln: &str,
+    patched: &str,
+    min_sim: f64,
+    margin: f64,
+) -> Result<()> {
+    let it = load_index(target)?;
+    let vdb = Db::open(vuln).with_context(|| format!("opening vuln corpus {vuln}"))?;
+    let pdb = Db::open(patched).with_context(|| format!("opening patched corpus {patched}"))?;
+    let hits = triage(&it, &vdb, &pdb, min_sim, margin)?;
+
+    let vulns: Vec<_> = hits
+        .iter()
+        .filter(|h| h.verdict == Verdict::Vulnerable)
+        .collect();
+    println!(
+        "{} functions triaged: {} look vulnerable, {} patched, {} inconclusive",
+        hits.len(),
+        vulns.len(),
+        hits.iter().filter(|h| h.verdict == Verdict::Patched).count(),
+        hits.iter()
+            .filter(|h| h.verdict == Verdict::Inconclusive)
+            .count(),
+    );
+
+    if vulns.is_empty() {
+        println!("\nno function leans vulnerable above the margin. nothing to review.");
+        return Ok(());
+    }
+    // the review queue: strongest vulnerable lead first
+    println!("\nreview queue (vuln-leaning, strongest first):");
+    println!("   addr         vuln%  patched%  margin  matches");
+    for h in vulns {
+        println!(
+            "   {:#010x}  {:>5.1}   {:>6.1}   {:>+5.1}  {} vs {}",
+            h.entry,
+            h.vuln_sim * 100.0,
+            h.patched_sim * 100.0,
+            h.margin() * 100.0,
+            h.vuln_name,
+            h.patched_name,
+        );
+    }
     Ok(())
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -214,13 +214,7 @@ fn cmd_eval(a: &str, b: &str) -> Result<()> {
     Ok(())
 }
 
-fn cmd_triage(
-    target: &str,
-    vuln: &str,
-    patched: &str,
-    min_sim: f64,
-    margin: f64,
-) -> Result<()> {
+fn cmd_triage(target: &str, vuln: &str, patched: &str, min_sim: f64, margin: f64) -> Result<()> {
     let it = load_index(target)?;
     let vdb = Db::open(vuln).with_context(|| format!("opening vuln corpus {vuln}"))?;
     let pdb = Db::open(patched).with_context(|| format!("opening patched corpus {patched}"))?;
@@ -234,7 +228,9 @@ fn cmd_triage(
         "{} functions triaged: {} look vulnerable, {} patched, {} inconclusive",
         hits.len(),
         vulns.len(),
-        hits.iter().filter(|h| h.verdict == Verdict::Patched).count(),
+        hits.iter()
+            .filter(|h| h.verdict == Verdict::Patched)
+            .count(),
         hits.iter()
             .filter(|h| h.verdict == Verdict::Inconclusive)
             .count(),

--- a/crates/fnprint-core/src/lib.rs
+++ b/crates/fnprint-core/src/lib.rs
@@ -158,6 +158,33 @@ pub struct Named {
     pub similarity: f64,
 }
 
+/// best-scoring named function in a corpus for one print. narrows with the LSH
+/// bands first and falls back to the full set if no band hit. returns
+/// (similarity, name, binary). the preloaded `all` is the fallback pool.
+fn best_in_corpus(
+    fp: &Fingerprint,
+    db: &Db,
+    all: &[fnprint_db::FuncRec],
+) -> Result<Option<(f64, String, String)>> {
+    let cands = db.candidates(fp)?;
+    let pool: &[fnprint_db::FuncRec] = if cands.is_empty() { all } else { &cands };
+    let mut best: Option<(f64, String, String)> = None;
+    for c in pool {
+        if c.fp.complexity < MIN_COMPLEXITY {
+            continue;
+        }
+        let cname = match &c.name {
+            Some(n) => n,
+            None => continue,
+        };
+        let sim = fp.similarity(&c.fp);
+        if best.as_ref().map(|(s, _, _)| sim > *s).unwrap_or(true) {
+            best = Some((sim, cname.clone(), c.binary.clone()));
+        }
+    }
+    Ok(best)
+}
+
 /// for each function in the target that we can trust, pull the best-matching
 /// named function out of the corpus db. withholds tiny/low-signal functions.
 pub fn query_corpus(target: &[IndexedFunc], corpus: &Db, threshold: f64) -> Result<Vec<Named>> {
@@ -167,35 +194,112 @@ pub fn query_corpus(target: &[IndexedFunc], corpus: &Db, threshold: f64) -> Resu
         if f.fp.complexity < MIN_COMPLEXITY || f.fp.shingles == 0 {
             continue;
         }
-        // narrow with LSH, then score
-        let cands = corpus.candidates(&f.fp)?;
-        let pool = if cands.is_empty() { &named } else { &cands };
-        let mut best: Option<(f64, &str, &str)> = None;
-        for c in pool {
-            if c.fp.complexity < MIN_COMPLEXITY {
-                continue;
-            }
-            let sim = f.fp.similarity(&c.fp);
-            let cname = match &c.name {
-                Some(n) => n.as_str(),
-                None => continue,
-            };
-            if best.map(|(s, _, _)| sim > s).unwrap_or(true) {
-                best = Some((sim, cname, c.binary.as_str()));
-            }
-        }
-        if let Some((sim, name, bin)) = best {
+        if let Some((sim, name, bin)) = best_in_corpus(&f.fp, corpus, &named)? {
             if sim >= threshold {
                 out.push(Named {
                     entry: f.entry,
-                    guess: name.to_string(),
-                    from_binary: bin.to_string(),
+                    guess: name,
+                    from_binary: bin,
                     similarity: sim,
                 });
             }
         }
     }
     out.sort_by(|a, b| b.similarity.partial_cmp(&a.similarity).unwrap());
+    Ok(out)
+}
+
+// -------- triage (n-day: vulnerable vs patched, the actionable view) --------
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Verdict {
+    /// leans toward the known-vulnerable version, clear of the patched one
+    Vulnerable,
+    /// leans toward the patched version
+    Patched,
+    /// neither side is close enough, or the two are too close to separate
+    Inconclusive,
+}
+
+pub struct TriageHit {
+    pub entry: u64,
+    pub verdict: Verdict,
+    pub vuln_sim: f64,
+    pub vuln_name: String,
+    pub patched_sim: f64,
+    pub patched_name: String,
+}
+
+impl TriageHit {
+    /// how far the vulnerable side leads the patched side. negative means it
+    /// looks patched. this is the separation the reviewer actually cares about.
+    pub fn margin(&self) -> f64 {
+        self.vuln_sim - self.patched_sim
+    }
+}
+
+fn verdict_order(v: Verdict) -> u8 {
+    // vulnerable-leaning to the top of the review queue, patched to the bottom
+    match v {
+        Verdict::Vulnerable => 0,
+        Verdict::Inconclusive => 1,
+        Verdict::Patched => 2,
+    }
+}
+
+/// rank each target function against a known-vulnerable corpus and a known-patched
+/// corpus and call which side it leans to. a function close to the vulnerable
+/// version and clearly separated from the patched one is a candidate worth a
+/// human's time, which is more useful for n-day work than a single match score.
+///
+/// `min_sim`: a side has to be at least this similar to count as a real lead.
+/// `margin`: how far the two sides must separate before we commit to a verdict.
+/// the result is sorted as a review queue, strongest vulnerable lead first.
+pub fn triage(
+    target: &[IndexedFunc],
+    vuln: &Db,
+    patched: &Db,
+    min_sim: f64,
+    margin: f64,
+) -> Result<Vec<TriageHit>> {
+    let vuln_all = vuln.all()?;
+    let patched_all = patched.all()?;
+    let mut out = Vec::new();
+    for f in target {
+        if f.fp.complexity < MIN_COMPLEXITY || f.fp.shingles == 0 {
+            continue;
+        }
+        let (vuln_sim, vuln_name) = best_in_corpus(&f.fp, vuln, &vuln_all)?
+            .map(|(s, n, _)| (s, n))
+            .unwrap_or((0.0, String::new()));
+        let (patched_sim, patched_name) = best_in_corpus(&f.fp, patched, &patched_all)?
+            .map(|(s, n, _)| (s, n))
+            .unwrap_or((0.0, String::new()));
+
+        let top = vuln_sim.max(patched_sim);
+        let verdict = if top < min_sim {
+            Verdict::Inconclusive
+        } else if vuln_sim - patched_sim >= margin {
+            Verdict::Vulnerable
+        } else if patched_sim - vuln_sim >= margin {
+            Verdict::Patched
+        } else {
+            Verdict::Inconclusive
+        };
+        out.push(TriageHit {
+            entry: f.entry,
+            verdict,
+            vuln_sim,
+            vuln_name,
+            patched_sim,
+            patched_name,
+        });
+    }
+    out.sort_by(|a, b| {
+        verdict_order(a.verdict)
+            .cmp(&verdict_order(b.verdict))
+            .then(b.vuln_sim.partial_cmp(&a.vuln_sim).unwrap())
+    });
     Ok(out)
 }
 
@@ -213,6 +317,12 @@ pub struct EvalResult {
     pub fp: usize,
     /// same-named pairs we failed to call same
     pub fn_: usize,
+    /// 1-based rank of the correct match for each scored function. lets us ask
+    /// "does reviewing the top k candidates find it", not just the top-1 number.
+    pub ranks: Vec<usize>,
+    /// scored functions where the top-1 similarity was below SAME_THRESH, i.e.
+    /// the tool would decline to make a confident call rather than guess.
+    pub abstained: usize,
 }
 
 impl EvalResult {
@@ -246,6 +356,24 @@ impl EvalResult {
             self.tp as f64 / d as f64
         }
     }
+    /// fraction of scored functions whose correct match lands in the top k.
+    /// recall@5 answers "if an analyst looks at 5 candidates, do they find it".
+    pub fn recall_at(&self, k: usize) -> f64 {
+        if self.scored == 0 {
+            return 0.0;
+        }
+        let hits = self.ranks.iter().filter(|&&r| r <= k).count();
+        hits as f64 / self.scored as f64
+    }
+    /// how often the tool declined a confident top-1 call. high abstention with
+    /// high precision is the honest tradeoff: quiet when it isn't sure.
+    pub fn abstain_rate(&self) -> f64 {
+        if self.scored == 0 {
+            0.0
+        } else {
+            self.abstained as f64 / self.scored as f64
+        }
+    }
 }
 
 /// rank every signal-bearing function in A against all of B, using symbol names
@@ -263,6 +391,8 @@ pub fn eval(a: &[IndexedFunc], b: &[IndexedFunc]) -> EvalResult {
         tp: 0,
         fp: 0,
         fn_: 0,
+        ranks: Vec::new(),
+        abstained: 0,
     };
 
     for fa in a {
@@ -291,11 +421,15 @@ pub fn eval(a: &[IndexedFunc], b: &[IndexedFunc]) -> EvalResult {
         }
         if let Some(pos) = scored.iter().position(|(_, n)| *n == aname) {
             res.rr_sum += 1.0 / (pos as f64 + 1.0);
+            res.ranks.push(pos + 1); // 1-based rank for recall@k
         }
 
         // threshold-based precision/recall on the top-1 call
         let (top_sim, top_name) = scored[0];
         let predicted_same = top_sim >= SAME_THRESH;
+        if !predicted_same {
+            res.abstained += 1; // below threshold, we'd decline to call it
+        }
         let correct = top_name == aname;
         match (predicted_same, correct) {
             (true, true) => res.tp += 1,
@@ -379,5 +513,41 @@ mod tests {
         let rep = match_by_name(&a, &b);
         assert_eq!(rep.changed.len(), 0);
         assert_eq!(rep.low_signal, 1);
+    }
+
+    #[test]
+    fn triage_leans_to_matching_side() {
+        // vuln corpus holds the function at seed 3, patched holds it at seed 999.
+        // a target that behaves like seed 3 must come back Vulnerable, and one
+        // like seed 999 must come back Patched.
+        let vuln = Db::open_memory().unwrap();
+        vuln.insert("v1", Some("f"), 0x1000, "symtab", &ifunc("f", 3, 10).fp)
+            .unwrap();
+        let patched = Db::open_memory().unwrap();
+        patched
+            .insert("v2", Some("f"), 0x1000, "symtab", &ifunc("f", 999, 10).fp)
+            .unwrap();
+
+        let looks_vuln = triage(&[ifunc("x", 3, 10)], &vuln, &patched, 0.5, 0.1).unwrap();
+        assert_eq!(looks_vuln[0].verdict, Verdict::Vulnerable);
+        assert!(looks_vuln[0].margin() > 0.0);
+
+        let looks_patched = triage(&[ifunc("x", 999, 10)], &vuln, &patched, 0.5, 0.1).unwrap();
+        assert_eq!(looks_patched[0].verdict, Verdict::Patched);
+    }
+
+    #[test]
+    fn triage_abstains_when_nothing_close() {
+        // target matches neither side -> below min_sim -> Inconclusive
+        let vuln = Db::open_memory().unwrap();
+        vuln.insert("v1", Some("f"), 0x1000, "symtab", &ifunc("f", 3, 10).fp)
+            .unwrap();
+        let patched = Db::open_memory().unwrap();
+        patched
+            .insert("v2", Some("f"), 0x1000, "symtab", &ifunc("f", 999, 10).fp)
+            .unwrap();
+
+        let hits = triage(&[ifunc("x", 55555, 10)], &vuln, &patched, 0.9, 0.1).unwrap();
+        assert_eq!(hits[0].verdict, Verdict::Inconclusive);
     }
 }


### PR DESCRIPTION
adds a triage command for the n-day case a blueteamsec comment raised. instead of one match score you have to interpret, index the known-vulnerable and the patched version of a function separately, then rank an unknown build against both and report the margin. a function close to the vuln side and clear of the patched side goes to the top of a review queue. anything identical in both versions comes back inconclusive so unchanged code never gets flagged.

also added recall@3 / recall@5 and an abstention rate to eval. rank-1 alone hides that a 5-candidate review budget finds most of what the top hit misses, and that the tool declines a confident call when it isn't sure rather than guessing.

tested on a real patch: took zlib gcc -O0, added a length guard to adler32_z, built that as the patched corpus. triage against the original flagged only adler32_z (100% vuln vs 27% patched, +72 margin) and called the other 42 signal-bearing functions inconclusive, zero false positives. all 18 tests pass, clippy -D warnings and fmt clean.

new command:

    fnprint triage <target> --vuln vuln.db --patched patched.db
